### PR TITLE
Disable plugin if a URL isn't specified

### DIFF
--- a/lib/vagrant-cookbook-fetcher/config.rb
+++ b/lib/vagrant-cookbook-fetcher/config.rb
@@ -16,10 +16,9 @@ module VagrantPlugins
 
       def validate(machine)
         errors = []
-        unless @disable then
-          if @url == UNSET_VALUE
-            errors << "vagrant-cookbook-fetcher plugin requires a config parameter, 'url', which is missing."
-          end
+        if @url == UNSET_VALUE
+          # Disable vagrant cookbook fetcher if we don't specify a URL
+          @disable = true
         end
 
         { 'Cookbook Fetcher' => errors }


### PR DESCRIPTION
Rather than throw an error, this change disables vagrant-cookbook-fetcher.
Without this, any Vagrantfile that doesn't use vagrant-cookbook-fetcher will
throw an error, preventing you from using vagrant without configuring this
plugin.