### PR TITLE
don't try to run when URL hasn't been set

### DIFF
--- a/lib/vagrant-cookbook-fetcher/action_fetch_cookbooks.rb
+++ b/lib/vagrant-cookbook-fetcher/action_fetch_cookbooks.rb
@@ -7,22 +7,22 @@ module VagrantPlugins
       def initialize(app, env)
         @app = app
       end
-      
+
       def call(env)
 
         vcf_config = env[:machine].config.cookbook_fetcher
-        unless vcf_config.disable then
+        if vcf_config.url then
           CookbookFetcher.perform_fetch(\
-                                        :url => env[:machine].config.cookbook_fetcher.url,
+                                        :url => vcf_config.url,
                                         :logger => env[:ui],
                                         :path => env[:root_path]
                                         )
         else
           env[:ui].info "Cookbook fetching disabled, skipping"
         end
-        
+
         # Continue daisy chain
-        @app.call(env)        
+        @app.call(env)
       end
     end
   end

--- a/lib/vagrant-cookbook-fetcher/action_set_chef_paths.rb
+++ b/lib/vagrant-cookbook-fetcher/action_set_chef_paths.rb
@@ -5,13 +5,13 @@ module VagrantPlugins
       def initialize(app, env)
         @app = app
       end
-      
+
       def call(env)
         # there has got to be a better way
         provisioners_list = env[:machine].config.vm.provisioners
         chef_solo = provisioners_list.find { |p| p.name === :chef_solo }
 
-        if chef_solo then
+        if chef_solo and env[:machine].config.cookbook_fetcher.url then
           solo_cfg = chef_solo.config
 
           Dir.chdir(env[:root_path]) do
@@ -31,7 +31,7 @@ module VagrantPlugins
             solo_cfg.cookbooks_path = []
 
             # Read from filesystem
-            IO.readlines(".cookbook-order").each do |line| 
+            IO.readlines(".cookbook-order").each do |line|
               solo_cfg.cookbooks_path.push [ :host, line.chomp ]
             end
 
@@ -39,7 +39,7 @@ module VagrantPlugins
         end
 
         # Continue daisy chain
-        @app.call(env) 
+        @app.call(env)
       end
     end
   end

--- a/lib/vagrant-cookbook-fetcher/config.rb
+++ b/lib/vagrant-cookbook-fetcher/config.rb
@@ -2,29 +2,6 @@ module VagrantPlugins
   module CookbookFetcher
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :url
-      attr_accessor :disable
-
-      def initialize
-        super
-        @url     = UNSET_VALUE
-        @disable = UNSET_VALUE
-      end
-
-      def finalize!
-        @disable = false if @disable == UNSET_VALUE
-      end
-
-      def validate(machine)
-        errors = []
-        unless @disable then
-          if @url == UNSET_VALUE
-            errors << "vagrant-cookbook-fetcher plugin requires a config parameter, 'url', which is missing."
-          end
-        end
-
-        { 'Cookbook Fetcher' => errors }
-      end
-
     end
   end
 end


### PR DESCRIPTION
Having the plugin installed on my system means I can't use a VM definition that doesn't use the plugin. Setting "disable" is not an acceptable solution because it means I need to set options for a plugin I'm not using.