### PR TITLE
provision.name becomes provision.type

### DIFF
--- a/lib/vagrant-cookbook-fetcher/action_set_chef_paths.rb
+++ b/lib/vagrant-cookbook-fetcher/action_set_chef_paths.rb
@@ -8,8 +8,8 @@ module VagrantPlugins
       
       def call(env)
         # there has got to be a better way
-        provisioners_list = env[:machine].config.vm.provisioners
-        chef_solo = provisioners_list.find { |p| p.name === :chef_solo }
+        key = ::Gem::Specification::find_by_name('vagrant').version < Gem::Version.new('1.7.0') ? :name : :type
+        chef_solo = env[:machine].config.vm.provisioners.find { |p| p.send(key) === :chef_solo }
         vcf_config = env[:machine].config.cookbook_fetcher
 
         if chef_solo then


### PR DESCRIPTION
This change is required because of this commit:
https://github.com/mitchellh/vagrant/commit/97f9948fcee53530d8e527a1e0937f95bdc95ae7